### PR TITLE
Should fix https://github.com/gtfierro/mdal/issues/5

### DIFF
--- a/timeseriesdb.go
+++ b/timeseriesdb.go
@@ -116,23 +116,23 @@ func (b *btrdbClient) DoQuery(q Query) (*Timeseries, error) {
 
 	// number of streams per UUID. Its all different because we can apply different
 	// statistical modifiers to each variable/uuid separately
-	numMap := make(map[uuid.Array]int)
-	for idx, uuid := range q.uuids {
+	numMap := make(map[int]int)
+	for idx := range q.uuids {
 		if q.Time.Aligned && (q.Time.WindowSize > 0) {
 			if q.selectors[idx].DoMin() {
-				numMap[uuid.Array()]++
+				numMap[idx]++
 			}
 			if q.selectors[idx].DoMax() {
-				numMap[uuid.Array()]++
+				numMap[idx]++
 			}
 			if q.selectors[idx].DoMean() {
-				numMap[uuid.Array()]++
+				numMap[idx]++
 			}
 			if q.selectors[idx].DoCount() {
-				numMap[uuid.Array()]++
+				numMap[idx]++
 			}
 		} else {
-			numMap[uuid.Array()]++
+			numMap[idx]++
 		}
 	}
 
@@ -178,7 +178,7 @@ func (b *btrdbClient) DoQuery(q Query) (*Timeseries, error) {
 			done:     wg.Done,
 			ts:       ts,
 		}
-		idx += numMap[uuid.Array()]
+		idx += numMap[uuidIdx]
 		b.queries <- req
 	}
 	wg.Wait()


### PR DESCRIPTION
We were keeping track of the number of statistical summaries per
entry in the "composition" field. When indexing that structure with UUIDs,
we can run into a situation where if there are duplicate UUIDs in the
composition field, the index into the result Timeseries structure becomes off.