### PR TITLE
Allow UUID definition in variable definitions

### DIFF
--- a/params.go
+++ b/params.go
@@ -18,6 +18,8 @@ type VarParams struct {
 	// variable in the query. All other returned variables will be considered
 	// additional metadata for that uuid
 	Definition string
+	// alternatively specify a list of UUIDs
+	UUIDS []string
 	// Units to retrieve this variable as (e.g. F, C, %RH, ppm, etc)
 	Units string
 	// internal field: the uuids this variable resolves to


### PR DESCRIPTION
You can now use 'UUIDS' (list of strings) in the variable definitions
and apply unit conversions to those. If there is a Brick query in the
variable definition, the explicitly specified UUIDS will be *appended*
(not unioned) to the list of UUIDs that resolve from that query.

- [x] ~~https://docs.xbos.io/mdal.html#using fix documentation~~ https://github.com/SoftwareDefinedBuildings/XBOSDocs/commit/ef1a5ceea60548a0ad3862803404bfa3dbfc6e74